### PR TITLE
icqq 0.0.21不能用了 升级0.0.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "chalk": "^5.0.1",
     "chokidar": "^3.5.3",
     "https-proxy-agent": "5.0.1",
-    "icqq": "^0.0.21",
+    "icqq": "^0.0.22",
     "image-size": "^1.0.2",
     "inquirer": "^8.2.4",
     "lodash": "^4.17.21",


### PR DESCRIPTION
icqq 0.0.21不能用了 升级0.0.22
21版本一直提示重连升级22版即可