### PR TITLE
修改 Dockerfile 中使用 apt 镜像源的方式

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,7 @@
 FROM debian:stable AS resource
 
-COPY sources.list  /etc/apt/sources.list
-
-RUN apt-get update \
+RUN sed -i "s/deb.debian.org/mirrors.ustc.edu.cn/g" /etc/apt/sources.list \
+    && apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y wget xz-utils dos2unix \
     && wget https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-$(dpkg --print-architecture)-static.tar.xz \
@@ -21,9 +20,8 @@ COPY --from=resource /res/ffmpeg/ffmpeg /usr/bin/ffmpeg
 
 COPY --from=resource /res/ffmpeg/ffprobe /usr/bin/ffprobe
 
-COPY sources.list  /etc/apt/sources.list
-
-RUN apt-get update \
+RUN sed -i "s/deb.debian.org/mirrors.ustc.edu.cn/g" /etc/apt/sources.list \
+    && apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y curl wget gnupg git python3-pip fonts-wqy-microhei xfonts-utils chromium fontconfig libxss1 libgl1 \
     && apt-get autoremove \

--- a/docker/sources.list
+++ b/docker/sources.list
@@ -1,8 +1,0 @@
-deb http://mirrors.aliyun.com/debian/ buster main non-free contrib
-deb-src http://mirrors.aliyun.com/debian/ buster main non-free contrib
-deb http://mirrors.aliyun.com/debian-security buster/updates main
-deb-src http://mirrors.aliyun.com/debian-security buster/updates main
-deb http://mirrors.aliyun.com/debian/ buster-updates main non-free contrib
-deb-src http://mirrors.aliyun.com/debian/ buster-updates main non-free contrib
-deb http://mirrors.aliyun.com/debian/ buster-backports main non-free contrib
-deb-src http://mirrors.aliyun.com/debian/ buster-backports main non-free contrib


### PR DESCRIPTION
镜像底包的 Debian 发行版本实际上并不能确定，直接替换 sources.list 是一种比较奇怪的做法....