### PR TITLE
Docker 相关功能修复

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ yunzai
 /data/
 /temp/
 /pnpm-lock.yaml
+/entrypoint.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ COPY --from=resource /res/ffmpeg/ffprobe /usr/bin/ffprobe
 RUN sed -i "s/deb.debian.org/mirrors.ustc.edu.cn/g" /etc/apt/sources.list \
     && apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y curl wget gnupg git python3-pip fonts-wqy-microhei xfonts-utils chromium fontconfig libxss1 libgl1 \
+    && apt-get install -y curl wget gnupg git python3-pip python3-venv fonts-wqy-microhei xfonts-utils chromium fontconfig libxss1 libgl1 \
     && apt-get autoremove \
     && apt-get clean
 
@@ -37,8 +37,11 @@ RUN git config --global --add safe.directory '*' \
 RUN npm install pnpm -g
 
 RUN ln -s /usr/bin/python3 /usr/bin/python \
-    && curl -fsSL https://install.python-poetry.org | python - \
-    && ln -s /$HOME/.local/bin/poetry /usr/bin \
+    && POETRY_HOME=$HOME/venv-poetry \
+    && python -m venv $POETRY_HOME \
+    && $POETRY_HOME/bin/pip install --upgrade pip setuptools -i https://pypi.tuna.tsinghua.edu.cn/simple \
+    && $POETRY_HOME/bin/pip install poetry -i https://pypi.tuna.tsinghua.edu.cn/simple \
+    && ln -s $POETRY_HOME/bin/poetry /usr/bin \
     && poetry config virtualenvs.in-project true
 
 RUN rm -rf /var/cache/* \

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -28,10 +28,10 @@ if [[ -z $(git status -s) ]]; then
     echo -e " ${Warn} ${YellowBG} 当前工作区有修改，尝试暂存后更新。${Font}"
     git add .
     git stash
-    git pull origin main --allow-unrelated-histories --rebase
+    git pull origin master --allow-unrelated-histories --rebase
     git stash pop
 else
-    git pull origin main --allow-unrelated-histories
+    git pull origin master --allow-unrelated-histories
 fi
 
 if [[ ! -f "$HOME/.ovo/yunzai.ok" ]]; then


### PR DESCRIPTION
1. 修改 poetry 的安装方式。由于网络环境的问题，通过官方脚本安装可能会卡死。
2. 修改 entrypoint.sh 中的分支名称，从 `main` 修改为 `master`
3. 将 `entrypoint.sh` 添加到 `.gitignore` 中