### PR TITLE
fix: 修复白名单为空数组时所有群聊都不生效的问题

### DIFF
--- a/lib/plugins/loader.js
+++ b/lib/plugins/loader.js
@@ -686,13 +686,12 @@ class PluginsLoader {
 
     if (e.group_id) {
       /** 白名单群 */
-      if (other.whiteGroup) {
-        if (other.whiteGroup.includes(Number(e.group_id))) return true
-        return false
+      if (Array.isArray(other.whiteGroup) && other.whiteGroup.length > 0) {
+        return other.whiteGroup.includes(Number(e.group_id));
       }
       /** 黑名单群 */
-      if (other.blackGroup && other.blackGroup.includes(Number(e.group_id))) {
-        return false
+      if (Array.isArray(other.blackGroup) && other.blackGroup.length > 0) {
+        return !other.blackGroup.includes(Number(e.group_id))
       }
     }
 


### PR DESCRIPTION
比如这种情况

![image](https://user-images.githubusercontent.com/34293221/232964141-72863cef-e82e-4497-9057-91feefad32fb.png)
