### PR TITLE
[WIP]: 重构消息发送的相关逻辑

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -1,20 +1,82 @@
+import { EventEmitter } from 'events';
+import lodash from 'lodash';
+
 import './config/init.js'
 import ListenerLoader from './listener/loader.js'
-import { Client } from 'icqq'
-import cfg from './config/config.js'
+import Messager from './messager/Messager.js';
 
-export default class Yunzai extends Client {
-  // eslint-disable-next-line no-useless-constructor
-  constructor (conf) {
-    super(conf)
+const botProxyHandler = {
+  get(target, prop, receiver) {
+    if (prop in receiver) {
+      return Reflect.get(...arguments);
+    }
+    logger.warn("直接调用 Bot 的方法或属性 " + prop + " 已过时，请通过 e.bot 访问。\n调用堆栈: " + (new Error()).stack);
+    return receiver.primaryMessager[prop];
+  },
+  set(target, prop, value, receiver) {
+    if (prop in receiver) {
+      return Reflect.set(...arguments);
+    }
+    logger.warn("直接调用 Bot 的方法或属性 " + prop + " 已过时，请通过 e.bot 访问。\n调用堆栈: " + (new Error()).stack);
+    receiver.primaryMessager[prop] = value;
+    return true;
+  }
+};
+
+class MessagerManager extends EventEmitter {
+  constructor(messagers) {
+    super();
+    if (!messagers || !lodash.isArray(messagers) || lodash.isEmpty(messagers)) {
+      logger.error("加载消息发送器失败，请检查配置.");
+      process.exit(1);
+    }
+    this.messagers = messagers;
+    this.primaryMessager = messagers[0];
   }
 
-  /** 登录机器人 */
-  static async run () {
-    const bot = new Yunzai(cfg.bot)
-    /** 加载icqq事件监听 */
-    await ListenerLoader.load(bot)
-    await bot.login(cfg.qq, cfg.pwd)
-    return bot
+  on() {
+    let [val, callback] = [arguments[0], arguments[1]];
+    for (let messager of this.messagers) {
+      messager.on(val, (e) => {
+        // TODO 包装 icqq event
+        e.bot = messager;
+        super.emit(val, e);
+      });
+    }
+    super.on(val, (e) => {
+      callback(e);
+    });
+  }
+
+  once() {
+    let [val, callback] = [arguments[0], arguments[1]];
+    for (let messager of this.messagers) {
+      messager.on(val, (e) => {
+        // TODO 包装 icqq event
+        e.bot = messager;
+        super.emit(val, e);
+      });
+    }
+    super.once(val, (e) => {
+      callback(e);
+    });
+  }
+}
+
+export default class Yunzai extends MessagerManager {
+  constructor(messagers) {
+    super(messagers);
+  }
+
+  static async run() {
+    const messagers = Messager.getMessagers();
+    const bot = new Proxy(new Yunzai(messagers), botProxyHandler);
+    /** 加载 Yunzai 事件监听 */
+    await ListenerLoader.load(bot);
+    /** 触发 messager 的登陆操作 **/
+    for (let messager of messagers) {
+      await messager.login();
+    }
+    return bot;
   }
 }

--- a/lib/events/online.js
+++ b/lib/events/online.js
@@ -29,7 +29,7 @@ export default class onlineEvent extends EventListener {
   async loginMsg () {
     if (!cfg.bot.online_msg) return
     if (!cfg.masterQQ || !cfg.masterQQ[0]) return
-    let key = `Yz:loginMsg:${Bot.uin}`
+    let key = `Yz:loginMsg:${Bot.primaryMessager.uin}`
 
     if (await redis.get(key)) return
 

--- a/lib/messager/Messager.js
+++ b/lib/messager/Messager.js
@@ -1,0 +1,30 @@
+import fs from 'node:fs'
+import lodash from 'lodash'
+import cfg from '../config/config.js'
+import { Data } from '#miao'
+
+let messagerBackends = {}
+
+async function registerMessagerBackends() {
+  const subFolders = fs.readdirSync(`${process.cwd()}/messagers`, { withFileTypes: true }).filter((dirent) => dirent.isDirectory())
+  for (let subFolder of subFolders) {
+    let name = subFolder.name
+    let messager = await Data.importDefault(`/messagers/${name}/index.js`)
+    if (!messager.id || !messager.type || !messager.constructor || !messager.segment || !lodash.isFunction(messager.constructor)) {
+      logger.warn('消息发送器 ' + (messager.id || subFolder.name) + ' 不可用')
+    }
+    messagerBackends[messager.id] = messager
+    logger.mark('[消息发送器加载]: 导入 ' + messager.id)
+  }
+}
+
+await registerMessagerBackends()
+
+export default {
+  getMessagers() {
+    // TODO 多个消息发送器适配
+    const messager = new (messagerBackends[cfg.messager?.name || 'icqq'].constructor)();
+    const messagers = [messager];
+    return messagers;
+  }
+}

--- a/lib/plugins/loader.js
+++ b/lib/plugins/loader.js
@@ -158,7 +158,6 @@ class PluginsLoader {
    * @param e icqq Events
    */
   async deal (e) {
-    e.bot = Bot
     /** 检查频道消息 */
     if (this.checkGuildMsg(e)) return
     /** 检查黑白名单 */

--- a/messagers/.gitignore
+++ b/messagers/.gitignore
@@ -1,0 +1,6 @@
+*
+!.gitignore
+
+!icqq
+!icqq/**
+icqq/config.yaml

--- a/messagers/icqq/index.js
+++ b/messagers/icqq/index.js
@@ -1,0 +1,15 @@
+import {ICQQClient, ICQQSegment} from './lib/icqq.js'
+
+/**
+ * @returns messager 消息发送器对象
+ * @returns messager.id 消息发送器ID，对应messager中选择的id
+ * @returns messager.type 消息发送器的类型，保留字段，暂时支持'IM'
+ * @returns messager.constructor 消息发送器的构造器
+ * @returns messager.segment 消息发送器所提供的消息构造器
+ */
+export default {
+  id: 'icqq',
+  type: 'IM',
+  constructor: ICQQClient,
+  segment: ICQQSegment
+}

--- a/messagers/icqq/lib/icqq.js
+++ b/messagers/icqq/lib/icqq.js
@@ -1,0 +1,18 @@
+import '../../../lib/config/init.js';
+import cfg from '../../../lib/config/config.js';
+import { Client } from "icqq";
+import { segment } from 'icqq';
+
+class ICQQClient extends Client {
+  constructor() {
+    super(cfg.bot)
+  }
+
+  login() {
+    super.login(cfg.qq, cfg.pwd)
+  }
+}
+
+const ICQQSegment = segment;
+
+export { ICQQClient, ICQQSegment };


### PR DESCRIPTION
目前的 Yunzai-Bot 运行在 icqq 的 Client 上，整体使用了 icqq 的事件循环，这使得抽离出 icqq 变得十分困难。为了抽离 icqq 的运行逻辑，需要 Yunzai-Bot 自己提供事件循环。

这个 PR 主要有以下更改：
(1) 抽象出了消息发送器 Messager，Messager 需要实现 icqq Client 的一些方法和属性来保证 Yunzai-Bot 的正常运行，这降低了 Yunzai Bot 移植到除QQ外的其他即时通信软件的难度。
(2) 为 Yunzai Bot 提供自己的事件循环。每当 Messager 触发一个事件，会将该事件在 Yunzai-Bot 的事件循环中触发一个相同名称的事件，以给 Yunzai Bot 的插件使用。
(3) 使用 Proxy 给实现 Yunzai Bot 单例实现 Messager 的方法。这是必须的，因为原来的 Bot 对象的类继承自 icqq Client。
