### PR TITLE
插件中使用 e.bot 而不是全局 Bot

### DIFF
--- a/lib/common/common.js
+++ b/lib/common/common.js
@@ -69,15 +69,15 @@ async function makeForwardMsg (e, msg = [], dec = '') {
   // 是频道直接返回 join
   if (e.isGuild) return msg.join("\n")
 
-  let nickname = Bot.nickname
+  let nickname = e.bot.nickname
 
   if (e.isGroup) {
-    let info = await Bot.getGroupMemberInfo(e.group_id, Bot.uin)
+    let info = await e.bot.getGroupMemberInfo(e.group_id, e.bot.uin)
     nickname = info.card || info.nickname
   }
 
   let userInfo = {
-    user_id: Bot.uin,
+    user_id: e.bot.uin,
     nickname
   }
 

--- a/lib/plugins/loader.js
+++ b/lib/plugins/loader.js
@@ -367,9 +367,9 @@ class PluginsLoader {
             e.img.push(val.url)
             break
           case 'at':
-            if (val.qq == Bot.uin) {
+            if (val.qq == e.bot.uin) {
               e.atBot = true
-            } else if (val.id == Bot.tiny_id) {
+            } else if (val.id == e.bot.tiny_id) {
               e.atBot = true
             /** 多个at 以最后的为准 */
             } else if (val.id) {
@@ -526,9 +526,9 @@ class PluginsLoader {
             logger.warn(err)
           })
         } else {
-          let friend = Bot.fl.get(e.user_id)
+          let friend = e.bot.fl.get(e.user_id)
           if (!friend) return
-          return await Bot.pickUser(e.user_id).sendMsg(msg).catch((err) => {
+          return await e.bot.pickUser(e.user_id).sendMsg(msg).catch((err) => {
             logger.warn(err)
           })
         }

--- a/plugins/example/进群退群通知.js
+++ b/plugins/example/进群退群通知.js
@@ -17,7 +17,7 @@ export class newcomer extends plugin {
     /** 冷却cd 30s */
     let cd = 30
 
-    if (this.e.user_id == Bot.uin) return
+    if (this.e.user_id == this.e.bot.uin) return
 
     /** cd */
     let key = `Yz:newcomers:${this.e.group_id}`
@@ -46,7 +46,7 @@ export class outNotice extends plugin {
   }
 
   async accept () {
-    if (this.e.user_id == Bot.uin) return
+    if (this.e.user_id == this.e.bot.uin) return
 
     let name, msg
     if (this.e.member) {

--- a/plugins/genshin/apps/abbrSet.js
+++ b/plugins/genshin/apps/abbrSet.js
@@ -61,10 +61,10 @@ export class abbrSet extends plugin {
     if (this.e.isMaster) return true
     /** 管理员 */
     if (abbrSetAuth == 1) {
-      if (!Bot.gml.has(this.e.group_id)) {
+      if (!this.e.bot.gml.has(this.e.group_id)) {
         return false
       }
-      if (!Bot.gml.get(this.e.group_id).get(this.e.user_id)) {
+      if (!this.e.bot.gml.get(this.e.group_id).get(this.e.user_id)) {
         return false
       }
       if (!this.e.member.is_admin) {
@@ -163,19 +163,19 @@ export class abbrSet extends plugin {
 
     let title = `${role.name}别名，${list.length}个`
 
-    msg = await this.makeForwardMsg(Bot.uin, title, msg)
+    msg = await this.makeForwardMsg(this.e.bot.uin, title, msg)
 
     await this.e.reply(msg)
   }
 
   async makeForwardMsg (qq, title, msg) {
-    let nickname = Bot.nickname
+    let nickname = this.e.bot.nickname
     if (this.e.isGroup) {
-      let info = await Bot.getGroupMemberInfo(this.e.group_id, qq)
+      let info = await this.e.bot.getGroupMemberInfo(this.e.group_id, qq)
       nickname = info.card ?? info.nickname
     }
     let userInfo = {
-      user_id: Bot.uin,
+      user_id: this.e.bot.uin,
       nickname
     }
 

--- a/plugins/genshin/apps/gcLog.js
+++ b/plugins/genshin/apps/gcLog.js
@@ -139,7 +139,7 @@ export class gcLog extends plugin {
       return
     }
 
-    let friend = Bot.fl.get(Number(this.e.user_id))
+    let friend = this.e.bot.fl.get(Number(this.e.user_id))
     if (!friend) {
       await this.reply('无法发送文件，请先添加好友')
       return

--- a/plugins/genshin/model/mysNews.js
+++ b/plugins/genshin/model/mysNews.js
@@ -323,7 +323,7 @@ export default class MysNews extends base {
     if (sended) return
 
     // 判断是否存在群关系
-    if (!Bot.gl.get(Number(groupId))) {
+    if (!this.e.bot.gl.get(Number(groupId))) {
       logger.error(`[米游社${typeName}推送] 群${groupId}未关联`)
       return
     }
@@ -340,7 +340,7 @@ export default class MysNews extends base {
     }
 
     this.pushGroup[groupId]++
-    this.e.group = Bot.pickGroup(Number(groupId))
+    this.e.group = this.e.bot.pickGroup(Number(groupId))
     this.e.group_id = Number(groupId)
     let tmp = await this.replyMsg(this[postId].img, `原神${typeName}推送：${this[postId].title}`)
 

--- a/plugins/other/sendLog.js
+++ b/plugins/other/sendLog.js
@@ -80,13 +80,13 @@ export class sendLog extends plugin {
   }
 
   async makeForwardMsg (title, msg) {
-    let nickname = Bot.nickname
+    let nickname = this.e.bot.nickname
     if (this.e.isGroup) {
-      let info = await Bot.getGroupMemberInfo(this.e.group_id, Bot.uin)
+      let info = await this.e.bot.getGroupMemberInfo(this.e.group_id, this.e.bot.uin)
       nickname = info.card ?? info.nickname
     }
     let userInfo = {
-      user_id: Bot.uin,
+      user_id: this.e.bot.uin,
       nickname
     }
 

--- a/plugins/other/update.js
+++ b/plugins/other/update.js
@@ -262,13 +262,13 @@ export class update extends plugin {
   }
 
   async makeForwardMsg (title, msg, end) {
-    let nickname = Bot.nickname
+    let nickname = this.e.bot.nickname
     if (this.e.isGroup) {
-      let info = await Bot.getGroupMemberInfo(this.e.group_id, Bot.uin)
+      let info = await this.e.bot.getGroupMemberInfo(this.e.group_id, this.e.bot.uin)
       nickname = info.card ?? info.nickname
     }
     let userInfo = {
-      user_id: Bot.uin,
+      user_id: this.e.bot.uin,
       nickname
     }
 

--- a/plugins/system/add.js
+++ b/plugins/system/add.js
@@ -99,8 +99,8 @@ export class add extends plugin {
     
     /** 添加全局表情，存入到机器人qq文件中 */
     if (this.isGlobal) {
-      this.group_id = Bot.uin;
-      return Bot.uin;
+      this.group_id = this.e.bot.uin;
+      return this.e.bot.uin;
     }
     
     if (this.e.isGroup) {
@@ -128,10 +128,10 @@ export class add extends plugin {
       return false
     }
     if (groupCfg.imgAddLimit == 1) {
-      if (!Bot.gml.has(this.group_id)) {
+      if (!this.e.bot.gml.has(this.group_id)) {
         return false
       }
-      if (!Bot.gml.get(this.group_id).get(this.e.user_id)) {
+      if (!this.e.bot.gml.get(this.group_id).get(this.e.user_id)) {
         return false
       }
       if (!this.e.member.is_admin) {
@@ -155,7 +155,7 @@ export class add extends plugin {
     }
 
     if (this.e.at) {
-      let at = lodash.filter(this.e.message, (o) => { return o.type == 'at' && o.qq != Bot.uin })
+      let at = lodash.filter(this.e.message, (o) => { return o.type == 'at' && o.qq != this.e.bot.uin })
       if (at.length > 1) {
         this.e.reply('添加错误：只能@一个人当关键词')
         return false
@@ -202,7 +202,7 @@ export class add extends plugin {
       /** 过滤#添加 */
       .replace(/#|＃|图片|表情|添加|删除|全局/g, '')
       /** 过滤@ */
-      .replace(new RegExp('{at:' + Bot.uin + '}', 'g'), '')
+      .replace(new RegExp('{at:' + this.e.bot.uin + '}', 'g'), '')
       .trim()
 
     this.keyWord = this.trimAlias(this.keyWord)
@@ -245,7 +245,7 @@ export class add extends plugin {
 
     for (let i in message) {
       if (message[i].type == 'at') {
-        if (message[i].qq == Bot.uin) {
+        if (message[i].qq == this.e.bot.uin) {
           this.e.reply('添加内容不能@机器人！')
           return
         }
@@ -301,7 +301,7 @@ export class add extends plugin {
           continue
         }
         if (msg[i].type == 'at') {
-          if (msg[i].qq == Bot.uin) {
+          if (msg[i].qq == this.e.bot.uin) {
             delete msg[i]
             continue
           } else {
@@ -327,12 +327,12 @@ export class add extends plugin {
   
   saveGlobalJson() {
     let obj = {};
-    for (let [k, v] of textArr[Bot.uin]) {
+    for (let [k, v] of textArr[this.e.bot.uin]) {
       obj[k] = v;
     }
 
     fs.writeFileSync(
-      `${this.path}${Bot.uin}.json`,
+      `${this.path}${this.e.bot.uin}.json`,
       JSON.stringify(obj, "", "\t")
     );
   }
@@ -390,7 +390,7 @@ export class add extends plugin {
 
     let keyWord = this.e.toString()
       .replace(/#|＃/g, '')
-      .replace(`{at:${Bot.uin}}`, '')
+      .replace(`{at:${this.e.bot.uin}}`, '')
       .trim()
 
     keyWord = this.trimAlias(keyWord)
@@ -399,14 +399,14 @@ export class add extends plugin {
     if (isNaN(keyWord)) {
       num = keyWord.charAt(keyWord.length - 1)
 
-      if (!isNaN(num) && !textArr[this.group_id].has(keyWord) && !textArr[Bot.uin].has(keyWord)) {
+      if (!isNaN(num) && !textArr[this.group_id].has(keyWord) && !textArr[this.e.bot.uin].has(keyWord)) {
         keyWord = lodash.trimEnd(keyWord, num).trim()
         num--
       }
     }
 
     let msg = textArr[this.group_id].get(keyWord) || []
-    let globalMsg = textArr[Bot.uin].get(keyWord) || []
+    let globalMsg = textArr[this.e.bot.uin].get(keyWord) || []
     if (lodash.isEmpty(msg) && lodash.isEmpty(globalMsg)) return false
 
     msg = [...msg, ...globalMsg]
@@ -513,11 +513,11 @@ export class add extends plugin {
   
   /** 初始化全局已添加内容 */
   initGlobalTextArr() {
-    if (textArr[Bot.uin]) return;
+    if (textArr[this.e.bot.uin]) return;
 
-    textArr[Bot.uin] = new Map();
+    textArr[this.e.bot.uin] = new Map();
 
-    let globalPath = `${this.path}${Bot.uin}.json`;
+    let globalPath = `${this.path}${this.e.bot.uin}.json`;
     if (!fs.existsSync(globalPath)) {
       return;
     }
@@ -529,20 +529,20 @@ export class add extends plugin {
         if (text[i][0] && !Array.isArray(text[i][0])) {
           text[i] = [text[i]];
         }
-        textArr[Bot.uin].set(String(i), text[i]);
+        textArr[this.e.bot.uin].set(String(i), text[i]);
       }
     } catch (error) {
       logger.error(`json格式错误：${globalPath}`);
-      delete textArr[Bot.uin];
+      delete textArr[this.e.bot.uin];
       return false;
     }
 
     /** 加载表情 */
-    let globalFacePath = `${this.facePath}${Bot.uin}`;
+    let globalFacePath = `${this.facePath}${this.e.bot.uin}`;
 
     if (fs.existsSync(globalFacePath)) {
       const files = fs
-        .readdirSync(`${this.facePath}${Bot.uin}`)
+        .readdirSync(`${this.facePath}${this.e.bot.uin}`)
         .filter((file) => /\.(jpeg|jpg|png|gif)$/g.test(file));
 
       for (let val of files) {
@@ -550,9 +550,9 @@ export class add extends plugin {
         tmp[0] = tmp[0].replace(/_[0-9]{10}$/, "");
         if (/at|image/g.test(val)) continue;
 
-        if (textArr[Bot.uin].has(tmp[0])) continue;
+        if (textArr[this.e.bot.uin].has(tmp[0])) continue;
 
-        textArr[Bot.uin].set(tmp[0], [
+        textArr[this.e.bot.uin].set(tmp[0], [
           [
             {
               local: `${globalFacePath}/${val}`,
@@ -737,19 +737,19 @@ export class add extends plugin {
       title = `表情${search}，${count}条`
     }
 
-    let forwardMsg = await this.makeForwardMsg(Bot.uin, title, msg, end)
+    let forwardMsg = await this.makeForwardMsg(this.e.bot.uin, title, msg, end)
 
     this.e.reply(forwardMsg)
   }
 
   async makeForwardMsg (qq, title, msg, end = '') {
-    let nickname = Bot.nickname
+    let nickname = this.e.bot.nickname
     if (this.e.isGroup) {
-      let info = await Bot.getGroupMemberInfo(this.e.group_id, qq)
+      let info = await this.e.bot.getGroupMemberInfo(this.e.group_id, qq)
       nickname = info.card ?? info.nickname
     }
     let userInfo = {
-      user_id: Bot.uin,
+      user_id: this.e.bot.uin,
       nickname
     }
 
@@ -808,7 +808,7 @@ export class add extends plugin {
 
       for (let qq of tmp) {
         qq = qq.match(/[1-9][0-9]{4,14}/g)[0]
-        let member = await await Bot.getGroupMemberInfo(this.group_id, Number(qq)).catch(() => { })
+        let member = await await this.e.bot.getGroupMemberInfo(this.group_id, Number(qq)).catch(() => { })
         let name = member?.card ?? member?.nickname
         if (!name) continue
         msg = msg.replace(`{at:${qq}}`, `@${name}`)

--- a/plugins/system/invite.js
+++ b/plugins/system/invite.js
@@ -14,9 +14,9 @@ export class invite extends plugin {
       logger.mark(`[邀请加群]：${this.e.group_name}：${this.e.group_id}`)
       return
     }
-    Bot.logger.mark(`[主人邀请加群]：${this.e.group_name}：${this.e.group_id}`)
+    logger.mark(`[主人邀请加群]：${this.e.group_name}：${this.e.group_id}`)
     this.e.approve(true)
-    Bot.sendPrivateMsg(this.e.user_id, `已同意加群：${this.e.group_name}`).catch((err) => {
+    this.e.bot.sendPrivateMsg(this.e.user_id, `已同意加群：${this.e.group_name}`).catch((err) => {
       logger.error(err)
     })
   }

--- a/plugins/system/quit.js
+++ b/plugins/system/quit.js
@@ -10,7 +10,7 @@ export class quit extends plugin {
   }
 
   async accept () {
-    if (this.e.user_id != Bot.uin) return
+    if (this.e.user_id != this.e.bot.uin) return
 
     let other = cfg.other
     if (other.autoQuit <= 0) return

--- a/plugins/system/status.js
+++ b/plugins/system/status.js
@@ -28,7 +28,7 @@ export class status extends plugin {
   }
 
   async statusMaster () {
-    let runTime = moment().diff(moment.unix(Bot.stat.start_time), 'seconds')
+    let runTime = moment().diff(moment.unix(this.e.bot.stat.start_time), 'seconds')
     let Day = Math.floor(runTime / 3600 / 24)
     let Hour = Math.floor((runTime / 3600) % 24)
     let Min = Math.floor((runTime / 60) % 60)


### PR DESCRIPTION
对于 plugins 中的代码，尽可能的使用 `e.bot` 而不是全局的 `Bot` 变量，便于之后的迁移工作

目前还未替换的 Bot 变量：
(1) `lib/common/common.js` 的 `relpyPrivate` 
(2) `lib/events/online.js` 的 `onlineEvent.loginMsg`
(3) `plugins/other/restart.js` 的 `Restart`

本地测试时，对每个修改过的插件发送1-2个指令触发回调，没发现问题。需要的话可以进行更详细的测试。

Related: #50
