### PR TITLE
 support external chromium instance (#72) 

### DIFF
--- a/config/default_config/bot.yaml
+++ b/config/default_config/bot.yaml
@@ -11,6 +11,8 @@ ffprobe_path:
 
 # chromium其他路径
 chromium_path: 
+# puppeteer接口地址
+puppeteer_ws: 
   
 # 米游社接口代理地址，国际服用
 proxyAddress: 

--- a/renderers/puppeteer/config_default.yaml
+++ b/renderers/puppeteer/config_default.yaml
@@ -5,6 +5,10 @@
 # chromiumPath: C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe
 chromiumPath:
 
+# puppeteer websocket 地址。连接单独存在的 chromium。
+# puppeteerWS: 'ws://browserless:3000'
+puppeteerWS:
+
 # headless
 headless: true
 

--- a/renderers/puppeteer/lib/puppeteer.js
+++ b/renderers/puppeteer/lib/puppeteer.js
@@ -69,31 +69,29 @@ export default class PuppeteerRenderer {
 
     let connectFlag = false
     try {
-      // 如果是pm2启动，尝试连接已有实例
-      if (process.env.pm_id) {
-        // 获取Mac地址
-        if (!mac) {
-          mac = await this.getMac()
-          this.browserMacKey = `Yz:chromium:browserWSEndpoint:${mac}`
-        }
-        // 是否有browser实例
-        const browserUrl = (await redis.get(this.browserMacKey)) || this.config.wsEndpoint
-        if (browserUrl) {
-          const browserWSEndpoint = await puppeteer.connect({ browserWSEndpoint: browserUrl }).catch((err) => {
-            logger.error('puppeteer Chromium 缓存的实例已关闭')
-            redis.del(this.browserMacKey)
-          })
-          // 如果有实例，直接使用
-          if (browserWSEndpoint) {
-            this.browser = browserWSEndpoint
-            if (this.browser) {
-              connectFlag = true
-            }
+      // 获取Mac地址
+      if (!mac) {
+        mac = await this.getMac()
+        this.browserMacKey = `Yz:chromium:browserWSEndpoint:${mac}`
+      }
+      // 是否有browser实例
+      const browserUrl = (await redis.get(this.browserMacKey)) || this.config.wsEndpoint
+      if (browserUrl) {
+        logger.mark(`puppeteer Chromium from ${browserUrl}`)
+        const browserWSEndpoint = await puppeteer.connect({ browserWSEndpoint: browserUrl }).catch((err) => {
+          logger.error('puppeteer Chromium 缓存的实例已关闭')
+          redis.del(this.browserMacKey)
+        })
+        // 如果有实例，直接使用
+        if (browserWSEndpoint) {
+          this.browser = browserWSEndpoint
+          if (this.browser) {
+            connectFlag = true
           }
         }
       }
     } catch (e) {
-      logger.error('puppeteer Chromium 尝试连接已有实例失败')
+      logger.mark('puppeteer Chromium 不存在已有实例')
     }
 
     if (!this.browser || !connectFlag) {

--- a/renderers/puppeteer/lib/puppeteer.js
+++ b/renderers/puppeteer/lib/puppeteer.js
@@ -35,6 +35,10 @@ export default class PuppeteerRenderer {
       /** chromium其他路径 */
       this.config.executablePath = config.chromiumPath || cfg?.bot?.chromium_path
     }
+    if (config.puppeteerWS || cfg?.bot?.puppeteer_ws) {
+      /** chromium其他路径 */
+      this.config.wsEndpoint = config.puppeteerWS || cfg?.bot?.puppeteer_ws
+    }
 
     this.html = {}
     this.watcher = {}
@@ -73,7 +77,7 @@ export default class PuppeteerRenderer {
           this.browserMacKey = `Yz:chromium:browserWSEndpoint:${mac}`
         }
         // 是否有browser实例
-        const browserUrl = await redis.get(this.browserMacKey)
+        const browserUrl = (await redis.get(this.browserMacKey)) || this.config.wsEndpoint
         if (browserUrl) {
           const browserWSEndpoint = await puppeteer.connect({ browserWSEndpoint: browserUrl }).catch((err) => {
             logger.error('puppeteer Chromium 缓存的实例已关闭')


### PR DESCRIPTION
docker compose example, when using [this image](https://github.com/browserless/chrome):
the `volume target` of `temp/` shout be the same as Yunzai.
```yaml
services:
  browser:
    image: browserless/chrome
    restart: always
    environment:
      - ALLOW_FILE_PROTOCOL=true
      #  set timeout to 30 days, to omit error logs from Yunzai
      - CONNECTION_TIMEOUT=2592000
    volumes:
    - type: bind
      source: ./temp
      target: /app/temp
```

`config/bot.yaml` example:
```yaml
puppeteer_ws: 'ws://browser:3000'
```