### PR TITLE
修改强制更新的方法

### DIFF
--- a/plugins/other/update.js
+++ b/plugins/other/update.js
@@ -104,7 +104,7 @@ export class update extends plugin {
     let type = '更新'
     if (this.e.msg.includes('强制')) {
       type = '强制更新'
-      cm = `git reset --hard origin/master && ${cm}`
+      cm = `git fetch --all && git reset --hard && ${cm}`
     }
 
     if (plugin) {


### PR DESCRIPTION
强制更新后总会提示
> Error: Command failed: git -C ./plugins/yunzai-plugin/ pull --no-rebase
来自 https://github.com/Lycofuture/yunzai-plugin
   d84f8d5..216b378  main       -> origin/main
error: 您对下列文件的本地修改将被合并操作覆盖：
	xxx.js
请在合并前提交或贮藏您的修改。
正在终止
更新 d84f8d5..216b378

所以修改强制更新方法，使其彻底强制更新