### PR TITLE
修复绑定UID的bug

### DIFF
--- a/plugins/genshin/model/user.js
+++ b/plugins/genshin/model/user.js
@@ -153,9 +153,13 @@ export default class User extends base {
   async bingUid () {
     let uid = this.e.msg.match(/[1|2|5-9][0-9]{8}/g)
     if (!uid) return
+    let game = 'gs'
+    if (this.e.isSr) {
+      game = 'sr'
+    }
     uid = uid[0]
     let user = await this.user()
-    await user.addRegUid(uid, this.e)
+    await user.addRegUid(uid, game)
     return await this.showUid()
   }
 


### PR DESCRIPTION
最近更新后一些群友出现UID消失且无法绑定UID的BUG
打log定位了一下应该是`plugins/genshin/model/user.js`下`user.addRegUid`接口使用错误的原因
尝试进行了修复