### PR TITLE
Dockerfile: use node:lts-bullseye-slim

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN dos2unix /res/entrypoint.sh \
     && chmod +x /res/entrypoint.sh
 
 
-FROM node:lts-slim AS runtime
+FROM node:lts-bullseye-slim AS runtime
 
 ARG BUNDLE_FFMPEG true
 ARG BUNDLE_POETRY true


### PR DESCRIPTION
Debian 已经发行至版本 Bookworm (Debian 12)，并将默认的 Python 版本切换至 Python 3.11，Docker 所提供的 node 镜像也做了相应的更新。但是实际上 py-plugin 中的很多插件在 Python 3.11 上并不一定能够成功运行，这里强行指定版本为 Bullseye (Debian 11) 来确保兼容性。
