### PR TITLE
修正在消息关键词中指定数字大于9时无法正确读取对应映射关系的问题

### DIFF
--- a/plugins/system/add.js
+++ b/plugins/system/add.js
@@ -395,7 +395,7 @@ export class add extends plugin {
 
     let num = 0
     if (isNaN(keyWord)) {
-      num = keyWord.charAt(keyWord.length - 1)
+      num = keyWord.trim().match(/[0-9]+/g)[0]
 
       if (!isNaN(num) && !textArr[this.group_id].has(keyWord) && !textArr[this.e.bot.uin].has(keyWord)) {
         keyWord = lodash.trimEnd(keyWord, num).trim()


### PR DESCRIPTION
现行版本中，这个实现无法正常指定 index 大于 10 的表情/文字。
比如输入`测试10`，即使`测试`这个关键词里有超过十条 mapping record，他依旧取不到。因为在这个例子中 `num` 的初始读数为 0，然后触发了下一行的 if 继而变成了 -1，而 -1 不是一个有效的 array index，所以无法正常读取。