### PR TITLE
适配一下`WeChat-plugin`

### DIFF
--- a/lib/common/common.js
+++ b/lib/common/common.js
@@ -67,8 +67,6 @@ function mkdirs(dirname) {
  * @param msgsscr 转发信息是否伪装
  */
 async function makeForwardMsg(e, msg = [], dec = '', msgsscr = false) {
-  /** 是频道插件直接返回 */
-  if (e.QQGuild) return msg
 
   if (!Array.isArray(msg)) msg = [msg]
 

--- a/lib/plugins/loader.js
+++ b/lib/plugins/loader.js
@@ -440,7 +440,7 @@ class PluginsLoader {
       e.isGuild = true
     }
 
-    if (e.user_id && cfg.masterQQ.includes(Number(e.user_id))) {
+    if (e.user_id && cfg.masterQQ.includes(Number(e.user_id) || e.user_id)) {
       e.isMaster = true
     }
 
@@ -486,7 +486,7 @@ class PluginsLoader {
             text = lodash.truncate(e.sender.card, { length: 10 })
           }
           if (at === true) {
-            at = Number(e.user_id)
+            at = Number(e.user_id) || e.user_id
           } else if (!isNaN(at)) {
             if (e.isGuild) {
               text = e.sender?.nickname
@@ -703,18 +703,18 @@ class PluginsLoader {
     if (e.test) return true
 
     /** 黑名单qq */
-    if (other.blackQQ && other.blackQQ.includes(Number(e.user_id))) {
+    if (other.blackQQ && other.blackQQ.includes(Number(e.user_id) || e.user_id)) {
       return false
     }
 
     if (e.group_id) {
       /** 白名单群 */
       if (Array.isArray(other.whiteGroup) && other.whiteGroup.length > 0) {
-        return other.whiteGroup.includes(Number(e.group_id))
+        return other.whiteGroup.includes(Number(e.group_id) || e.group_id)
       }
       /** 黑名单群 */
       if (Array.isArray(other.blackGroup) && other.blackGroup.length > 0) {
-        return !other.blackGroup.includes(Number(e.group_id))
+        return !other.blackGroup.includes(Number(e.group_id) || e.group_id)
       }
     }
 


### PR DESCRIPTION
去除转发识别直接返回，有部分插件是手动书写方法，已使用其他方法实现
`ComWeChatBotClient`的`user_id`和`group_id`都是字符串，在此的情况下，不能正确识别id，导致黑白名单和主人无法生效问题