### PR TITLE
update icqq to v0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "chalk": "^5.3.0",
     "chokidar": "^3.5.3",
     "https-proxy-agent": "7.0.1",
-    "icqq": "^0.5.3",
+    "icqq": "^0.6.1",
     "image-size": "^1.0.2",
     "inquirer": "^9.2.10",
     "lodash": "^4.17.21",


### PR DESCRIPTION
因为 icqq 在 0.6.0 版本中修正了大量与消息签名相关的 bug，所以应该要跟进一下依赖更新