### PR TITLE
[bug修复]亚服18开头UID匹配问题

### DIFF
--- a/plugins/genshin/apps/user.js
+++ b/plugins/genshin/apps/user.js
@@ -101,7 +101,7 @@ export class user extends plugin {
   /** 绑定uid */
   saveUid() {
     if (!this.e.msg) return
-    let uid = this.e.msg.match(/([1-9]|18)[0-9]{8}/g)
+    let uid = this.e.msg.match(/(18|[1-9])[0-9]{8}/g)
     if (!uid) {
       this.reply("原神UID输入错误", false, { at: true })
       return
@@ -114,7 +114,7 @@ export class user extends plugin {
   /** 绑定星铁uid */
   saveSrUid() {
     if (!this.e.msg) return
-    let uid = this.e.msg.match(/([1-9]|18)[0-9]{8}/g)
+    let uid = this.e.msg.match(/(18|[1-9])[0-9]{8}/g)
     if (!uid) {
       this.reply("星铁UID输入错误", false, { at: true })
       return

--- a/plugins/genshin/model/exportLog.js
+++ b/plugins/genshin/model/exportLog.js
@@ -182,7 +182,7 @@ export default class ExportLog extends base {
 
   /** json导入抽卡记录 */
   async logJson() {
-    let uid = /([1-9]|18)[0-9]{8}/g.exec(this.e.file.name)[0]
+    let uid = /(18|[1-9])[0-9]{8}/g.exec(this.e.file.name)[0]
     let textPath = `${this.path}${this.e.file.name}`
     /** 获取文件下载链接 */
     let fileUrl = await this.e.friend.getFileUrl(this.e.file.fid)

--- a/plugins/genshin/model/gsCfg.js
+++ b/plugins/genshin/model/gsCfg.js
@@ -164,7 +164,7 @@ class GsCfg {
   }
 
   getMsgUid(msg) {
-    let ret = /([1-9]|18)[0-9]{8}/g.exec(msg)
+    let ret = /(18|[1-9])[0-9]{8}/g.exec(msg)
     if (!ret) return false
     return ret[0]
   }

--- a/plugins/genshin/model/mys/mysInfo.js
+++ b/plugins/genshin/model/mys/mysInfo.js
@@ -105,7 +105,7 @@ export default class MysInfo {
     }
 
     let matchUid = (msg = '') => {
-      let ret = /([1-9]|18)[0-9]{8}/g.exec(msg)
+      let ret = /(18|[1-9])[0-9]{8}/g.exec(msg)
       if (!ret) return false
       return ret[0]
     }

--- a/plugins/genshin/model/user.js
+++ b/plugins/genshin/model/user.js
@@ -204,7 +204,7 @@ export default class User extends base {
 
   /** 绑定uid，若有ck的话优先使用ck-uid */
   async bingUid() {
-    let uid = this.e.msg.match(/([1-9]|18)[0-9]{8}/g)
+    let uid = this.e.msg.match(/(18|[1-9])[0-9]{8}/g)
     if (!uid) return
     uid = uid[0]
     let user = await this.user()


### PR DESCRIPTION
原本的`/([1-9]|18)[0-9]{8}/g`在匹配亚服18开头的10位uid时，会匹配为国服1开头的9位UID，修改正则，优先匹配18开头