### PR TITLE
修复米游社公告

### DIFF
--- a/plugins/genshin/model/mysNews.js
+++ b/plugins/genshin/model/mysNews.js
@@ -273,6 +273,9 @@ export default class MysNews extends base {
   }
 
   replyMsg(img, title) {
+    if (!Array.isArray(img)) {
+      img = [img];
+    }
     if (!img || img.length <= 0) return false
     if (title) img = [title, ...img]
     if (img.length <= 2) return img

--- a/plugins/genshin/model/mysNews.js
+++ b/plugins/genshin/model/mysNews.js
@@ -274,7 +274,7 @@ export default class MysNews extends base {
 
   replyMsg(img, title) {
     if (!Array.isArray(img)) {
-      img = [img];
+      img = [img]
     }
     if (!img || img.length <= 0) return false
     if (title) img = [title, ...img]


### PR DESCRIPTION
解决如果 img 不是数组的问题，不影响正常使用