### PR TITLE
指定 art-template 版本

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "ksr": "node ./lib/tools/ksr.js"
   },
   "dependencies": {
-    "art-template": "^4.13.2",
+    "art-template": "4.13.2",
     "chalk": "^5.4.1",
     "chokidar": "^4.0.3",
     "https-proxy-agent": "7.0.6",


### PR DESCRIPTION
~~4.13.3版本包不完整，运行时会报错，未修复之前只能固定版本~~
4.13.4已回滚，但仍建议考虑固定版本的必要性